### PR TITLE
Fix tooltips not showing up in tier 3 double chests

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,1 +1,1 @@
-- Updated pack format
+- Fixed tooltips not showing up in tier 3 double chests

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,19 +1,19 @@
 org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 
-jei_version=7.1.0.11
+jei_version=7.1.3.19
 hwyla_version=1.10.10-B77_1.16.1
-corelib_version=1.0.0
+corelib_version=1.0.2
 
 mod_packagename=de.maxhenkel.storage
 mod_id=storage_overhaul
 mod_name=Storage Overhaul
 mod_vendor=Max Henkel
-mod_version=1.16.2-1.0.2
+mod_version=1.16.2-1.0.3
 mod_minecraft_version=1.16.2
 mod_forge_version=[33,)
 
-forge_version=33.0.2
+forge_version=33.0.20
 mappings_version=20200514-1.16
 
 curse_id=382599

--- a/src/main/java/de/maxhenkel/storage/gui/HugeChestScreen.java
+++ b/src/main/java/de/maxhenkel/storage/gui/HugeChestScreen.java
@@ -19,7 +19,6 @@ public class HugeChestScreen extends ContainerScreen<HugeChestContainer> {
     public HugeChestScreen(HugeChestContainer container, PlayerInventory playerInventory, ITextComponent name) {
         super(container, playerInventory, name);
         this.playerInventory = playerInventory;
-        //passEvents = false;
         xSize = 338;
 
         inventoryRows = container.getNumRows();
@@ -30,6 +29,12 @@ public class HugeChestScreen extends ContainerScreen<HugeChestContainer> {
     protected void func_230451_b_(MatrixStack matrixStack, int mouseX, int mouseY) {
         field_230712_o_.func_238421_b_(matrixStack, field_230704_d_.getString(), 8F, 6F, FONT_COLOR);
         field_230712_o_.func_238421_b_(matrixStack, playerInventory.getDisplayName().getString(), 89F, (float) (ySize - 96 + 2), FONT_COLOR);
+    }
+
+    @Override
+    public void func_230430_a_(MatrixStack matrixStack, int x, int y, float f) {
+        super.func_230430_a_(matrixStack, x, y, f);
+        func_230459_a_(matrixStack, x, y);
     }
 
     @Override


### PR DESCRIPTION
Closes #2